### PR TITLE
Table importdefinitions_log is not generated at install

### DIFF
--- a/lib/ImportDefinitions/Plugin.php
+++ b/lib/ImportDefinitions/Plugin.php
@@ -57,7 +57,7 @@ class Plugin extends PluginLib\AbstractPlugin implements PluginLib\PluginInterfa
           `id` int NOT NULL AUTO_INCREMENT PRIMARY KEY,
           `definition` int NOT NULL,
           `o_id` int NOT NULL
-        ");
+        );");
 
         return true;
     }


### PR DESCRIPTION
Plugin is accessible, routine fails with a MySQL statement: Mysqli prepare error: Table 'mysql.importdefinitions_log' doesn't exist