### PR TITLE
Added config renderTo for Window

### DIFF
--- a/src/ImportDefinitionsBundle/Resources/public/pimcore/js/definition/configDialog.js
+++ b/src/ImportDefinitionsBundle/Resources/public/pimcore/js/definition/configDialog.js
@@ -120,6 +120,7 @@ pimcore.plugin.importdefinitions.definition.configDialog = Class.create({
         });
 
         this.window = new Ext.Window({
+            renderTo: 'pimcore_body',
             width: 800,
             height: 600,
             resizeable : true,


### PR DESCRIPTION
Fix:
- window with formpanel is rendered in the _pimcore_body_ element after selecting dropdown's value in the grid column

![wrong-position](https://user-images.githubusercontent.com/8125287/34523864-88cb1d70-f099-11e7-89b8-5a4f744ef154.png)
