### PR TITLE
fix: findRecord for fromColumn and toColumn store data

### DIFF
--- a/src/ImportDefinitionsBundle/Resources/public/pimcore/js/definition/item.js
+++ b/src/ImportDefinitionsBundle/Resources/public/pimcore/js/definition/item.js
@@ -553,8 +553,11 @@ pimcore.plugin.importdefinitions.definition.item = Class.create(coreshop.resourc
                                         width: 50,
                                         align: 'right',
                                         renderer: function (value, metadata, record) {
-                                            var fromColumn = fromColumnStore.findRecord('identifier', record.get('fromColumn'));
-                                            var toColumn = toColumnStore.findRecord('identifier', record.get('toColumn'));
+                                            var fromColumnRecordNum = fromColumnStore.findExact('identifier', record.get('fromColumn'));
+                                            var fromColumn = fromColumnStore.getAt(fromColumnRecordNum);
+
+                                            var toColumnRecordNum = toColumnStore.findExact('identifier', record.get('toColumn'));
+                                            var toColumn = toColumnStore.getAt(toColumnRecordNum);
 
                                             if (fromColumn && toColumn) {
                                                 var id = Ext.id();


### PR DESCRIPTION
findRecord finds the first matching Record in this store by a specific field value. It leads to wrong results in case if store has values which have similar part of string.

Example of store values:
testAAAA
testAA
test

testAAAA will be returned on any of those string searching, because it is first in the store