### PR TITLE
Fixes error on selecting provider in newly created definition.

### DIFF
--- a/src/ImportDefinitionsBundle/Resources/public/pimcore/js/definition/item.js
+++ b/src/ImportDefinitionsBundle/Resources/public/pimcore/js/definition/item.js
@@ -353,6 +353,7 @@ pimcore.plugin.importdefinitions.definition.item = Class.create(coreshop.resourc
 
             if (pimcore.plugin.importdefinitions.provider[provider] !== undefined) {
                 if (this.data.provider === null) {
+                    this.data.provider = provider;
                     this.save(function () {
                         this.updateProviderMapViews();
                     }.bind(this));
@@ -430,6 +431,9 @@ pimcore.plugin.importdefinitions.definition.item = Class.create(coreshop.resourc
                             data: config.fromColumns
                         });
 
+                        if(typeof config.toColumns == 'undefined') {
+                            config.toColumns = [];
+                        }
                         var toColumnStore = new Ext.data.Store({
                             data: config.toColumns
                         });


### PR DESCRIPTION
Problem:
On newly created definition, when provider is selected an error message is displayed. This prevents provider settings and mapping tabs to be reloaded - whole definition has to be closed and opened again.

This PR fixes that.