### PR TITLE
Sets modal = false on configDialog window.

### DIFF
--- a/src/ImportDefinitionsBundle/Resources/public/pimcore/js/definition/configDialog.js
+++ b/src/ImportDefinitionsBundle/Resources/public/pimcore/js/definition/configDialog.js
@@ -125,7 +125,7 @@ pimcore.plugin.importdefinitions.definition.configDialog = Class.create({
             width: 800,
             height: 600,
             resizeable : true,
-            modal: true,
+            modal: false,
             title: t('importdefinitions_config') + ' ' + fromColumn.data.label + ' => ' + toColumn.data.label,
             layout: 'fit',
             items: [this.configPanel]


### PR DESCRIPTION
This allows usage of drag & drop in interpreters and setter.
Also, windows with modal = true are rendered very slowly.