### PR TITLE
Changed system columns

### DIFF
--- a/src/ImportDefinitionsBundle/Controller/DefinitionController.php
+++ b/src/ImportDefinitionsBundle/Controller/DefinitionController.php
@@ -242,7 +242,7 @@ class DefinitionController extends ResourceController
         $fields = $class->getFieldDefinitions();
 
         $systemColumns = [
-            "published", "key", "parent", "type"
+            "o_published", "o_key", "o_parentId", "o_type"
         ];
 
         $result = array();


### PR DESCRIPTION
This enables system columns to be primary identifiers too. Only thing that would change is setting the parent, it's now expecting a ID instead of a DataObject.