### PR TITLE
fix: normalize the key the same way admin does

### DIFF
--- a/src/ImportDefinitionsBundle/Importer/Importer.php
+++ b/src/ImportDefinitionsBundle/Importer/Importer.php
@@ -416,7 +416,7 @@ final class Importer implements ImporterInterface
             }
 
             if ($obj instanceof AbstractObject) {
-                $key = File::getValidFilename($this->createKey($definition, $data));
+                $key = Service::getValidKey($this->createKey($definition, $data), 'object');
 
                 if ($definition->getRelocateExistingObjects() || !$obj->getId()) {
                     $obj->setParent(Service::createFolderByPath($this->createPath($definition, $data)));


### PR DESCRIPTION
Assuming `name=Foo Bar bla 123 / 456`

When importing with settings key set to `%Text(name);`, import process would normalize to "foo-bar-bla-123-456", admin would normalize to "Foo Bar bla 123 - 456". This streamlines the outcome.