### PR TITLE
Fix problem with xPath

### DIFF
--- a/src/ImportDefinitionsBundle/Provider/XmlProvider.php
+++ b/src/ImportDefinitionsBundle/Provider/XmlProvider.php
@@ -85,6 +85,6 @@ class XmlProvider implements ProviderInterface
         $file = sprintf('%s/%s', PIMCORE_PROJECT_ROOT, $params['file']);
         $xml = file_get_contents($file);
 
-        return $this->convertXmlToArray($xml, $configuration['xpath']);
+        return $this->convertXmlToArray($xml, $configuration['xPath']);
     }
 }

--- a/src/ImportDefinitionsBundle/Resources/public/pimcore/js/provider/xml.js
+++ b/src/ImportDefinitionsBundle/Resources/public/pimcore/js/provider/xml.js
@@ -17,7 +17,7 @@ pimcore.plugin.importdefinitions.provider.xml = Class.create(pimcore.plugin.impo
     getItems : function () {
         return [{
             xtype: 'textfield',
-            name: 'xpath',
+            name: 'xPath',
             fieldLabel: t('importdefinitions_xml_xpath'),
             anchor : '100%',
             value: this.data['xPath'] ? this.data.xPath : ''


### PR DESCRIPTION
When a user tries to save ImportDefinition settings for import from XML file the error occurs:
`configuration: This form should not contain extra fields.`
Moreover during a process of import no data if read from XML (error about missing XPath).
This pull request solves those problems.