### PR TITLE
added finished event handling

### DIFF
--- a/src/ImportDefinitionsBundle/ProcessManager/ImportDefinitionsReport.php
+++ b/src/ImportDefinitionsBundle/ProcessManager/ImportDefinitionsReport.php
@@ -22,6 +22,7 @@ class ImportDefinitionsReport implements ReportInterface
     const EVENT_TOTAL = 'import_definition.total: ';
     const EVENT_STATUS = 'import_definition.status: ';
     const EVENT_PROGRESS = 'import_definition.progress: ';
+    const EVENT_FINISHED = 'import_definition.finished: ';
     const EVENT_STATUS_ERROR = self::EVENT_STATUS . 'Error: ';
     const EVENT_STATUS_IMPORT_NEW = self::EVENT_STATUS . 'Import Object new';
     const EVENT_STATUS_IMPORT_EXISTING = self::EVENT_STATUS . 'Import Object';
@@ -175,7 +176,7 @@ class ImportDefinitionsReport implements ReportInterface
      * @param $result
      * @return bool
      */
-    protected function checkForTotal($line, $result)
+    protected function checkForTotal($line, &$result)
     {
         $pos = strpos($line, self::EVENT_TOTAL);
         if ($pos) {

--- a/src/ImportDefinitionsBundle/ProcessManager/ProcessManagerListener.php
+++ b/src/ImportDefinitionsBundle/ProcessManager/ProcessManagerListener.php
@@ -95,4 +95,12 @@ final class ProcessManagerListener
             $this->processLogger->info($this->process, ImportDefinitionsReport::EVENT_STATUS.$event->getSubject());
         }
     }
+
+    /**
+     * @param ImportDefinitionEvent $event
+     */
+    public function onFinishedEvent(ImportDefinitionEvent $event)
+    {
+        $this->processLogger->info($this->process, ImportDefinitionsReport::EVENT_FINISHED.$event->getSubject());
+    }
 }

--- a/src/ImportDefinitionsBundle/Resources/config/process_manager.yml
+++ b/src/ImportDefinitionsBundle/Resources/config/process_manager.yml
@@ -8,6 +8,7 @@ services:
             - { name: 'kernel.event_listener', event: 'import_definition.total', method: 'onTotalEvent' }
             - { name: 'kernel.event_listener', event: 'import_definition.progress', method: 'onProgressEvent' }
             - { name: 'kernel.event_listener', event: 'import_definition.status', method: 'onStatusEvent' }
+            - { name: 'kernel.event_listener', event: 'import_definition.finished', method: 'onFinishedEvent' }
 
     import_definition.process_manager.process:
         class: ImportDefinitionsBundle\ProcessManager\ImportDefinitionProcess


### PR DESCRIPTION
I see that 'object start' and 'object finished' avent are being triggered, but they duplicate status event. So I'have added finished event handling only.