### PR TITLE
Added SaveRunnerInterface

### DIFF
--- a/src/ImportDefinitionsBundle/Runner/SaveRunnerInterface.php
+++ b/src/ImportDefinitionsBundle/Runner/SaveRunnerInterface.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Import Definitions.
+ *
+ * LICENSE
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2016-2018 w-vision AG (https://www.w-vision.ch)
+ * @license    https://github.com/w-vision/ImportDefinitions/blob/master/gpl-3.0.txt GNU General Public License version 3 (GPLv3)
+ */
+
+namespace ImportDefinitionsBundle\Runner;
+
+use ImportDefinitionsBundle\Model\Mapping;
+use Pimcore\Model\DataObject\Concrete;
+use ImportDefinitionsBundle\Model\DefinitionInterface;
+
+interface SaveRunnerInterface extends RunnerInterface
+{
+    /**
+     * @param Concrete $object
+     * @param DefinitionInterface $definition
+     * @param $data
+     * @param $dataSet
+     * @param $params
+     * @param $filter
+     * @return mixed
+     */
+    public function shouldSaveObject(Concrete $object, DefinitionInterface $definition, $data, $dataSet, $params, $filter);
+}

--- a/src/ImportDefinitionsBundle/Runner/SaveRunnerInterface.php
+++ b/src/ImportDefinitionsBundle/Runner/SaveRunnerInterface.php
@@ -14,7 +14,6 @@
 
 namespace ImportDefinitionsBundle\Runner;
 
-use ImportDefinitionsBundle\Model\Mapping;
 use Pimcore\Model\DataObject\Concrete;
 use ImportDefinitionsBundle\Model\DefinitionInterface;
 
@@ -22,12 +21,10 @@ interface SaveRunnerInterface extends RunnerInterface
 {
     /**
      * @param Concrete $object
-     * @param DefinitionInterface $definition
      * @param $data
-     * @param $dataSet
+     * @param DefinitionInterface $definition
      * @param $params
-     * @param $filter
-     * @return mixed
+     * @return boolean
      */
-    public function shouldSaveObject(Concrete $object, DefinitionInterface $definition, $data, $dataSet, $params, $filter);
+    public function shouldSaveObject(Concrete $object, $data, DefinitionInterface $definition, $params);
 }


### PR DESCRIPTION
Added SaveRunnerInterface that allow the runner to perform extra validation and prevent the object from being saved.

In our project we use it like below to create a runner that only saves the object when there are changes to the data. This way we do not get any versions of the object that does not have changes. Makes the object history MUCH cleaner.

```
namespace Caupo\IntegrationBundle\Runner;

use Pimcore\Model\DataObject\Concrete;
use ImportDefinitionsBundle\Model\DefinitionInterface;
use ImportDefinitionsBundle\Model\Mapping;
use ImportDefinitionsBundle\Runner\SaveRunnerInterface;
use ImportDefinitionsBundle\Runner\SetterRunnerInterface;

class SkipNotModifiedRunner implements SaveRunnerInterface, SetterRunnerInterface
{
    private $hasChanges;

    public function preRun(Concrete $object, $data, DefinitionInterface $definition, $params)
    {
        $this->hasChanges = false;
    }

    public function postRun(Concrete $object, $data, DefinitionInterface $definition, $params)
    {

    }

    public function shouldSaveObject(Concrete $object, DefinitionInterface $definition, $data, $dataSet, $params, $filter) 
    {
        return $this->hasChanges;
    }

    public function shouldSetField(Concrete $object, Mapping $map, $value, $data, DefinitionInterface $definition, $params)
    {
        $getter = $map->getToColumn();
        if($map->getSetter() == 'localizedfield'){
            $getter = explode('~', $getter);
            $getter = sprintf('get%s', ucfirst($getter[0]));            
            $config = $map->getSetterConfig();            
            $oldValue = $object->$getter($config['language']);
        }else{
            $getter = sprintf('get%s', ucfirst($getter));
            $oldValue = $object->$getter();
        }
        $shouldSetValue = $value != $oldValue;
        $this->hasChanges = $this->hasChanges || $shouldSetValue;
        return $shouldSetValue;
    }
     
}
````