### PR TITLE
Add missing reverse interprerter iterator js to configuration

### DIFF
--- a/src/ImportDefinitionsBundle/DependencyInjection/Configuration.php
+++ b/src/ImportDefinitionsBundle/DependencyInjection/Configuration.php
@@ -131,6 +131,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('reverse_interpreter_empty')->defaultValue('/bundles/importdefinitions/pimcore/js/reverse_interpreters/empty.js')->end()
                             ->scalarNode('reverse_interpreter_nested')->defaultValue('/bundles/importdefinitions/pimcore/js/reverse_interpreters/nested.js')->end()
                             ->scalarNode('reverse_interpreter_expression')->defaultValue('/bundles/importdefinitions/pimcore/js/reverse_interpreters/expression.js')->end()
+                            ->scalarNode('reverse_interpreter_iterator')->defaultValue('/bundles/importdefinitions/pimcore/js/reverse_interpreters/iterator.js')->end()
                         ->end()
                     ->end()
                     ->arrayNode('css')


### PR DESCRIPTION
A tiny one... the js file for  reverse interpreter iterator was never added to the configuration so it was not loaded 