### PR TITLE
Add 'children' as system field for exports

### DIFF
--- a/src/ImportDefinitionsBundle/Controller/ExportDefinitionController.php
+++ b/src/ImportDefinitionsBundle/Controller/ExportDefinitionController.php
@@ -312,6 +312,11 @@ class ExportDefinitionController extends ResourceController
                 'fieldtype' => 'input',
                 'title' => 'Custom',
             ],
+            [
+                'name' => 'children',
+                'fieldtype' => 'input',
+                'title' => 'Children',
+            ],
         ];
 
         $result = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

Adds 'children' as a system field for exports. My primary use case is to include the sku of child products/variants of a 'configurable' product. The change is as simple as adding 'children' to the system fields array in ExportDefinitionController. The getter getChildren already exist and returns an array that can be handled with an Iterator-interpreter or soemthing like it.
