### PR TITLE
Catch all errors during import.

### DIFF
--- a/src/ImportDefinitionsBundle/Importer/Importer.php
+++ b/src/ImportDefinitionsBundle/Importer/Importer.php
@@ -255,7 +255,7 @@ final class Importer implements ImporterInterface
                 }
 
                 $count++;
-            } catch (\Exception $ex) {
+            } catch (\Throwable $ex) {
                 $this->logger->error($ex);
 
                 $exceptions[] = $ex;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

PHP Errors cause Imports to stop without logging anything for user (e.g. in Process Manager). Single-line errors break whole imports. This is especially annoying when users try to debug their mapping (most often it's a type error).
By catching Throwable instead of Exception, the import won't stop and additional info will be logged.