### PR TITLE
fix: drop unused variable in XmlProvider::serializeCollection

### DIFF
--- a/src/ImportDefinitionsBundle/Provider/XmlProvider.php
+++ b/src/ImportDefinitionsBundle/Provider/XmlProvider.php
@@ -110,7 +110,7 @@ class XmlProvider implements ProviderInterface, ExportProviderInterface, Artifac
         $writer = $this->getXMLWriter();
 
         $writer->startElement('object');
-        $this->serializeCollection($writer, 'object', $data);
+        $this->serializeCollection($writer, $data);
         $writer->endElement();
 
         $this->exportCounter++;
@@ -217,7 +217,7 @@ class XmlProvider implements ProviderInterface, ExportProviderInterface, Artifac
             if (null !== $key) {
                 $writer->writeAttribute('key', $key);
             }
-            $this->serializeCollection($writer, $name, $data);
+            $this->serializeCollection($writer, $data);
             $writer->endElement();
         } else {
             if ((string) $data) {
@@ -234,7 +234,7 @@ class XmlProvider implements ProviderInterface, ExportProviderInterface, Artifac
         }
     }
 
-    private function serializeCollection(\XMLWriter $writer, string $name, array $data): void
+    private function serializeCollection(\XMLWriter $writer, array $data): void
     {
         foreach ($data as $key => $value) {
             if (is_numeric($key)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | N/A

The unused variable. It triggers a bug if you have a collection of collections of properties.
