### PR TITLE
fix: allow NULL to be passed to IteratorInterpreter

### DIFF
--- a/src/ImportDefinitionsBundle/Interpreter/IteratorInterpreter.php
+++ b/src/ImportDefinitionsBundle/Interpreter/IteratorInterpreter.php
@@ -44,6 +44,9 @@ final class IteratorInterpreter implements InterpreterInterface, DataSetAwareInt
      */
     public function interpret(Concrete $object, $value, Mapping $map, $data, DefinitionInterface $definition, $params, $configuration)
     {
+        if (null === $value) {
+            return [];
+        }
         Assert::isArray($value, 'IteratorInterpreter can only be used with array values');
 
         $interpreter = $configuration['interpreter'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | N/A

Passing `NULL` to the iterator just returns an empty array, it's not a hard error anymore.
