### PR TITLE
Fix: No mapping if class has only translateable fields

### DIFF
--- a/src/ImportDefinitionsBundle/Resources/public/pimcore/js/export/fields.js
+++ b/src/ImportDefinitionsBundle/Resources/public/pimcore/js/export/fields.js
@@ -326,14 +326,12 @@ pimcore.plugin.importdefinitions.export.fields = Class.create({
                         baseNode.appendChild(node);
                     }
 
-                    if (this.tree[keys[i]].nodeType === 'object') {
-                        baseNode.expand();
-                    } else {
-                        baseNode.collapse();
-                    }
+                    baseNode.collapse();
                 }
             }
         }
+
+        tree.getRootNode().expand();
 
         return tree;
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

If I want export objects from a class which has only translateable fields, the mapping tab is empty.