### PR TITLE
Execute imports and exports with absolute file path

### DIFF
--- a/src/ImportDefinitionsBundle/Provider/AbstractFileProvider.php
+++ b/src/ImportDefinitionsBundle/Provider/AbstractFileProvider.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Import Definitions.
+ *
+ * LICENSE
+ *
+ * This source file is subject to the GNU General Public License version 3 (GPLv3)
+ * For the full copyright and license information, please view the LICENSE.md and gpl-3.0.txt
+ * files that are distributed with this source code.
+ *
+ * @copyright  Copyright (c) 2016-2018 w-vision AG (https://www.w-vision.ch)
+ * @license    https://github.com/w-vision/ImportDefinitions/blob/master/gpl-3.0.txt GNU General Public License version 3 (GPLv3)
+ */
+
+namespace ImportDefinitionsBundle\Provider;
+
+abstract class AbstractFileProvider
+{
+    /**
+     * @param string $file
+     *
+     * @return string
+     */
+    protected function getFile($file)
+    {
+        if (strpos($file, '/') !== 0) {
+            $file = sprintf('%s/%s', PIMCORE_PROJECT_ROOT, $file);
+        }
+
+        return $file;
+    }
+}

--- a/src/ImportDefinitionsBundle/Provider/CsvProvider.php
+++ b/src/ImportDefinitionsBundle/Provider/CsvProvider.php
@@ -22,7 +22,7 @@ use League\Csv\Reader;
 use League\Csv\Statement;
 use League\Csv\Writer;
 
-class CsvProvider implements ProviderInterface, ExportProviderInterface, ArtifactGenerationProviderInterface
+class CsvProvider extends AbstractFileProvider implements ProviderInterface, ExportProviderInterface, ArtifactGenerationProviderInterface
 {
     use ArtifactProviderTrait;
 
@@ -88,7 +88,7 @@ class CsvProvider implements ProviderInterface, ExportProviderInterface, Artifac
         $offset = $params['offset'];
         $limit = $params['limit'];
 
-        $file = sprintf('%s/%s', PIMCORE_PROJECT_ROOT, $params['file']);
+        $file = $this->getFile($params['file']);
 
         $csv = Reader::createFromPath($file, 'r');
         $csv->setDelimiter($delimiter);
@@ -138,7 +138,7 @@ class CsvProvider implements ProviderInterface, ExportProviderInterface, Artifac
             return;
         }
 
-        $file = sprintf('%s/%s', PIMCORE_PROJECT_ROOT, $params['file']);
+        $file = $this->getFile($params['file']);
 
         $headers = count($this->exportData) > 0 ? array_keys($this->exportData[0]) : [];
 

--- a/src/ImportDefinitionsBundle/Provider/ExcelProvider.php
+++ b/src/ImportDefinitionsBundle/Provider/ExcelProvider.php
@@ -26,7 +26,7 @@ use ImportDefinitionsBundle\ProcessManager\ArtifactGenerationProviderInterface;
 use ImportDefinitionsBundle\ProcessManager\ArtifactProviderTrait;
 use Pimcore\Model\Asset;
 
-class ExcelProvider implements ProviderInterface, ExportProviderInterface, ArtifactGenerationProviderInterface
+class ExcelProvider extends AbstractFileProvider implements ProviderInterface, ExportProviderInterface, ArtifactGenerationProviderInterface
 {
     use ArtifactProviderTrait;
 
@@ -75,7 +75,7 @@ class ExcelProvider implements ProviderInterface, ExportProviderInterface, Artif
      */
     public function getData($configuration, $definition, $params, $filter = null)
     {
-        $file = sprintf('%s/%s', PIMCORE_PROJECT_ROOT, $params['file']);
+        $file = $this->getFile($params['file']);
 
         $reader = $this->createReader($file);
         $sheetIterator = $reader->getSheetIterator();
@@ -104,7 +104,7 @@ class ExcelProvider implements ProviderInterface, ExportProviderInterface, Artif
         }
         $writer = $this->getWriter();
         $this->addHeaders($headers, $writer);
-        
+
         foreach ($data as $key => $item) {
             if (is_object($item)) {
                 $data[$key] = (string) $item;
@@ -125,7 +125,7 @@ class ExcelProvider implements ProviderInterface, ExportProviderInterface, Artif
             return;
         }
 
-        $file = sprintf('%s/%s', PIMCORE_PROJECT_ROOT, $params['file']);
+        $file = $this->getFile($params['file']);
         rename($this->getExportPath(), $file);
     }
 

--- a/src/ImportDefinitionsBundle/Provider/JsonProvider.php
+++ b/src/ImportDefinitionsBundle/Provider/JsonProvider.php
@@ -19,7 +19,7 @@ use ImportDefinitionsBundle\Model\ImportMapping\FromColumn;
 use ImportDefinitionsBundle\ProcessManager\ArtifactGenerationProviderInterface;
 use ImportDefinitionsBundle\ProcessManager\ArtifactProviderTrait;
 
-class JsonProvider implements ProviderInterface, ExportProviderInterface, ArtifactGenerationProviderInterface
+class JsonProvider extends AbstractFileProvider implements ProviderInterface, ExportProviderInterface, ArtifactGenerationProviderInterface
 {
     use ArtifactProviderTrait;
 
@@ -85,7 +85,7 @@ class JsonProvider implements ProviderInterface, ExportProviderInterface, Artifa
      */
     public function getData($configuration, $definition, $params, $filter = null)
     {
-        $file = sprintf('%s/%s', PIMCORE_PROJECT_ROOT, $params['file']);
+        $file = $this->getFile($params['file']);
 
         if (file_exists($file)) {
             $json = file_get_contents($file);
@@ -101,7 +101,7 @@ class JsonProvider implements ProviderInterface, ExportProviderInterface, Artifa
      */
     public function exportData($configuration, ExportDefinitionInterface $definition, $params)
     {
-        $file = sprintf('%s/%s', PIMCORE_PROJECT_ROOT, $params['file']);
+        $file = $this->getFile($params['file']);
 
         file_put_contents($file, json_encode($this->exportData));
     }

--- a/src/ImportDefinitionsBundle/Provider/XmlProvider.php
+++ b/src/ImportDefinitionsBundle/Provider/XmlProvider.php
@@ -23,7 +23,7 @@ use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Inflector\Inflector;
 use Symfony\Component\Process\Process;
 
-class XmlProvider implements ProviderInterface, ExportProviderInterface, ArtifactGenerationProviderInterface
+class XmlProvider extends AbstractFileProvider implements ProviderInterface, ExportProviderInterface, ArtifactGenerationProviderInterface
 {
     use ArtifactProviderTrait;
 
@@ -99,7 +99,7 @@ class XmlProvider implements ProviderInterface, ExportProviderInterface, Artifac
      */
     public function getData($configuration, $definition, $params, $filter = null)
     {
-        $file = sprintf('%s/%s', PIMCORE_PROJECT_ROOT, $params['file']);
+        $file = $this->getFile($params['file']);
         $xml = file_get_contents($file);
 
         return $this->convertXmlToArray($xml, $configuration['xPath']);
@@ -155,7 +155,7 @@ class XmlProvider implements ProviderInterface, ExportProviderInterface, Artifac
             return;
         }
 
-        $file = sprintf('%s/%s', PIMCORE_PROJECT_ROOT, $params['file']);
+        $file = $this->getFile($params['file']);
         rename($this->getExportPath(), $file);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

In the moment it is impossible to execute impots or exports with a absoulte file path
`php bin/console import-definitions:import -d 1 -p '{"file":"\/tmp\/migration.json"}'`
