### PR TITLE
fix: make sure ExcelProvider combines the headers with row

### DIFF
--- a/src/ImportDefinitionsBundle/Provider/ExcelProvider.php
+++ b/src/ImportDefinitionsBundle/Provider/ExcelProvider.php
@@ -83,10 +83,21 @@ class ExcelProvider extends AbstractFileProvider implements ProviderInterface, E
         $rowIterator = $sheetIterator->current()->getRowIterator();
 
         $headers = null;
-        return new ImportDataSet($rowIterator, function (array $row) use (&$headers) {
+        $headersCount = null;
+        return new ImportDataSet($rowIterator, function (array $row) use (&$headers, &$headersCount) {
             if (null === $headers) {
                 $headers = $row;
+                $headersCount = count($headers);
                 return null;
+            }
+
+            $rowCount = count($row);
+            if ($rowCount < $headersCount) {
+                // append missing values
+                $row = array_pad($row, $headersCount, null);
+            } elseif ($rowCount >= $headersCount) {
+                // remove overflow
+                $row = array_slice($row, 0, $headersCount);
             }
 
             return array_combine($headers, $row);


### PR DESCRIPTION
With empty trailing cells, ExcelProvider will truncate the row array to remove all trailing empty cells. This doesn't allow array_combine to work. This re-aligns the row to the headers by padding the array or removing the overflow should it happen.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | N/A
