### PR TITLE
change command for definitions:import

### DIFF
--- a/src/ImportDefinitionsBundle/Command/AbstractImportDefinitionCommand.php
+++ b/src/ImportDefinitionsBundle/Command/AbstractImportDefinitionCommand.php
@@ -67,7 +67,7 @@ abstract class AbstractImportDefinitionCommand extends AbstractCommand
         $type = $this->getType();
 
         $this
-            ->setName(sprintf('%s-definitions:import-definition', strtolower($type)))
+            ->setName(sprintf('%s-definitions:definition:import', strtolower($type)))
             ->setDescription(sprintf('Create a %s Definition.', $type))
             ->addArgument(
                 'path',

--- a/src/ImportDefinitionsBundle/Resources/config/services/commands.yml
+++ b/src/ImportDefinitionsBundle/Resources/config/services/commands.yml
@@ -30,7 +30,7 @@ services:
             - '@pimcore.dao.object_manager'
             - '@coreshop.resource_controller.form_factory'
         tags:
-            - { name: 'console.command', command: 'import-definitions:import-definition' }
+            - { name: 'console.command', command: 'import-definitions:definition:import' }
 
     ImportDefinitionsBundle\Command\ImportExportDefinitionCommand:
         arguments:
@@ -39,4 +39,4 @@ services:
             - '@pimcore.dao.object_manager'
             - '@coreshop.resource_controller.form_factory'
         tags:
-            - { name: 'console.command', command: 'export-definitions:import-definition' }
+            - { name: 'console.command', command: 'export-definitions:definition:import' }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

`import-definition:definition:import` and  `export-definition:definition:import`

@blankse We have to change the names again, since the currents interfere with currently used shortcurts like `im:im`