### PR TITLE
fix: properly COUNT(*) unpublished items

### DIFF
--- a/src/ImportDefinitionsBundle/Fetcher/ObjectsFetcher.php
+++ b/src/ImportDefinitionsBundle/Fetcher/ObjectsFetcher.php
@@ -58,6 +58,7 @@ class ObjectsFetcher implements FetcherInterface
 
         $classList = '\Pimcore\Model\DataObject\\'.ucfirst($class).'\Listing';
         $list = new $classList;
+        $list->setUnpublished($definition->isFetchUnpublished());
 
         if (isset($params['root'])) {
             $rootNode = Concrete::getById($params['root']);

--- a/src/ImportDefinitionsBundle/Fetcher/ObjectsFetcher.php
+++ b/src/ImportDefinitionsBundle/Fetcher/ObjectsFetcher.php
@@ -29,7 +29,6 @@ class ObjectsFetcher implements FetcherInterface
         $list = $this->getClassListing($definition, $params);
         $list->setLimit($limit);
         $list->setOffset($offset);
-        $list->setUnpublished(false === $definition->isFetchUnpublished());
 
         return $list->load();
     }


### PR DESCRIPTION
Applying `UnpublishedHelper::hideUnpublished()` is too late, it will have already counted only the published items.

This will cause a weird scenario where Pimcore thinks there are X items (published + unpublished), Exporter will say there are Y (published only), will then try to export MORE items, but only up to a number Z divisible by 50.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | N/A