### PR TITLE
Fix issue with case sensitive filesystems.

### DIFF
--- a/src/ImportDefinitionsBundle/Interpreter/MultiHrefInterpreter.php
+++ b/src/ImportDefinitionsBundle/Interpreter/MultiHrefInterpreter.php
@@ -32,7 +32,7 @@ class MultiHrefInterpreter implements InterpreterInterface, DataSetAwareInterfac
     {
         $objectClass = $configuration['class'];
 
-        $class = 'Pimcore\Model\DataObject\\' . $objectClass;
+        $class = 'Pimcore\Model\DataObject\\' . ucfirst($objectClass);
 
         if (Tool::classExists($class)) {
             $class = new $class();

--- a/src/ImportDefinitionsBundle/Interpreter/ObjectResolverInterpreter.php
+++ b/src/ImportDefinitionsBundle/Interpreter/ObjectResolverInterpreter.php
@@ -29,8 +29,8 @@ class ObjectResolverInterpreter implements InterpreterInterface
             return $value;
         }
 
-        $class = 'Pimcore\Model\DataObject\\'.$configuration['class'];
-        $lookup = 'getBy'.ucfirst($configuration['field']);
+        $class = 'Pimcore\Model\DataObject\\' . ucfirst($configuration['class']);
+        $lookup = 'getBy' . ucfirst($configuration['field']);
 
         /**
          * @var Listing $listing


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

When using the `ObjectResolverInterpreter` the importer will fail on case sensitive file systems. The following fatal error is thrown:
`Error: Class 'Pimcore\Model\DataObject\brand' not found in vendor/w-vision/import-definitions/src/ImportDefinitionsBundle/Interpreter/ObjectResolverInterpreter.php:38`

This is caused by PHP not able to find the class. The FQCN should be `Pimcore\Model\DataObject\Brand` to be able to load correctly.

I checked the pimcore core code and found several occasions where Pimcore also uppercases the first character to resolve this issue. So this should be the right solution.