### PR TITLE
If column is missing in dataset, null value will not be imported.

### DIFF
--- a/src/ImportDefinitionsBundle/Importer/Importer.php
+++ b/src/ImportDefinitionsBundle/Importer/Importer.php
@@ -355,9 +355,8 @@ final class Importer implements ImporterInterface
 
             if (array_key_exists($mapItem->getFromColumn(), $data)) {
                 $value = $data[$mapItem->getFromColumn()];
+                $this->setObjectValue($object, $mapItem, $value, $data, $dataSet, $definition, $params, $runner);
             }
-
-            $this->setObjectValue($object, $mapItem, $value, $data, $dataSet, $definition, $params, $runner);
         }
 
         $shouldSave = true;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | maybe?
| Deprecations? | no
| Fixed tickets | #190 partially

If the dataset is missing a column instead of setting null to target field it will be skipped.