### PR TITLE
Fix for Custom column mapping

### DIFF
--- a/src/ImportDefinitionsBundle/Importer/Importer.php
+++ b/src/ImportDefinitionsBundle/Importer/Importer.php
@@ -353,7 +353,7 @@ final class Importer implements ImporterInterface
         foreach ($definition->getMapping() as $mapItem) {
             $value = null;
 
-            if (array_key_exists($mapItem->getFromColumn(), $data)) {
+            if (array_key_exists($mapItem->getFromColumn(), $data) || $mapItem->getFromColumn() === "custom") {
                 $value = $data[$mapItem->getFromColumn()];
                 $this->setObjectValue($object, $mapItem, $value, $data, $dataSet, $definition, $params, $runner);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

My recent PR #191 introduced this problem - if we're using "Custom" as a fromColumn mapping, it won't be processed. This PR should fix this.